### PR TITLE
Changed to perform fulltext search. Added styling

### DIFF
--- a/lang/de/lang.php
+++ b/lang/de/lang.php
@@ -1,0 +1,4 @@
+<?php
+
+$lang['placeholder']		= 'Suchbegriff eingeben';
+$lang['results']			= 'Volltext Suchergebnisse';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -1,0 +1,4 @@
+<?php
+
+$lang['placeholder']		= 'Enter search term';
+$lang['results']			= 'Fulltext search results';

--- a/script.js
+++ b/script.js
@@ -6,7 +6,7 @@ jQuery(function () {
             var $output = $form.find('.searchform__qsearch_out');
             var $ns = $form.find('.searchform__ns');
 
-            $input.dw_qsearch({
+            $input.dw_fullsearch({
 
                 output: $output,
 
@@ -26,3 +26,194 @@ jQuery(function () {
 
         });
 });
+
+
+/** This is a slightly modified version of the original dokwuwiki qsearch.js
+ *  Modifications
+ *  - rename the function     "jquery.fn.dw_qsearch" -> "jquery.fn.dw_fullsearch"
+ *  - changed ajax call from  "call:qsearch"         -> "call: 'quickfullsearch'"
+ *  */
+jQuery.fn.dw_fullsearch = function (overrides) {
+
+    var dw_qsearch = {
+
+        output: '#fullsearch__out',
+
+        $inObj: this,
+        $outObj: null,
+        timer: null,
+        curRequest: null,
+
+        /**
+         * initialize the quick search
+         *
+         * Attaches the event handlers
+         *
+         */
+        init: function () {
+            var do_qsearch;
+            
+            dw_qsearch.$outObj = jQuery(dw_qsearch.output);
+
+            // objects found?
+            if (dw_qsearch.$inObj.length === 0 ||
+                dw_qsearch.$outObj.length === 0) {
+                return;
+            }
+
+            // attach eventhandler to search field
+            do_qsearch = function () {
+				
+				//document.getElementById('qfs_loader').style.visibility = 'visible'; // Gothe
+				
+                // abort any previous request
+                if (dw_qsearch.curRequest != null) {
+                    dw_qsearch.curRequest.abort();
+                }
+                var value = dw_qsearch.getSearchterm();
+                if (value === '') {
+                    dw_qsearch.clear_results();
+                    return;
+                }
+                dw_qsearch.$inObj.parents('form').addClass('searching');
+                dw_qsearch.curRequest = jQuery.post(
+                    DOKU_BASE + 'lib/exe/ajax.php',
+                    {
+                        call: 'quickfullsearch', // Gothe
+                        q: encodeURI(value)
+                    },
+                    dw_qsearch.onCompletion,
+                    'html'
+                );
+            };
+
+            dw_qsearch.$inObj.keyup(
+                function () {
+                    if (dw_qsearch.timer) {
+                        window.clearTimeout(dw_qsearch.timer);
+                        dw_qsearch.timer = null;
+                    }
+                    dw_qsearch.timer = window.setTimeout(do_qsearch, 500);
+                }
+            );
+
+            // attach eventhandler to output field
+            dw_qsearch.$outObj.click(dw_qsearch.clear_results);
+        },
+
+        /**
+         * Read search term from input
+         */
+        getSearchterm: function() {
+            return dw_qsearch.$inObj.val();
+        },
+
+        /**
+         * Empty and hide the output div
+         */
+        clear_results: function () {
+            dw_qsearch.$inObj.parents('form').removeClass('searching');
+            dw_qsearch.$outObj.hide();
+            dw_qsearch.$outObj.text('');
+            //document.getElementById('qfs_loader').style.visibility = 'hidden'; // Gothe
+        },
+
+        /**
+         * Callback. Reformat and display the results.
+         *
+         * Namespaces are shortened here to keep the results from overflowing
+         * or wrapping
+         *
+         * @param data The result HTML
+         */
+        onCompletion: function (data) {
+            var max, $links, too_big;
+            
+            //document.getElementById('qfs_loader').style.visibility = 'hidden'; // Gothe
+            
+            dw_qsearch.$inObj.parents('form').removeClass('searching');
+
+            dw_qsearch.curRequest = null;
+
+            if (data === '') {
+                dw_qsearch.clear_results();
+                return;
+            }
+
+            dw_qsearch.$outObj
+                .html(data)
+                .show()
+                .css('white-space', 'wrap');
+
+            // disable overflow during shortening
+            dw_qsearch.$outObj.find('li').css('overflow', 'visible');
+
+            $links = dw_qsearch.$outObj.find('a');
+            max = dw_qsearch.$outObj[0].clientWidth; // maximum width allowed (but take away paddings below)
+            if (document.documentElement.dir === 'rtl') {
+                max -= parseInt(dw_qsearch.$outObj.css('padding-left'));
+                too_big = function (l) {
+                    return l.offsetLeft < 0;
+                };
+            } else {
+                max -= parseInt(dw_qsearch.$outObj.css('padding-right'));
+                too_big = function (l) {
+                    return l.offsetWidth + l.offsetLeft > max;
+                };
+            }
+
+            $links.each(function () {
+                var start, length, replace, nsL, nsR, eli, runaway;
+
+                if (!too_big(this)) {
+                    return;
+                }
+
+                nsL = this.textContent.indexOf('(');
+                nsR = this.textContent.indexOf(')');
+                eli = 0;
+                runaway = 0;
+
+                while ((nsR - nsL > 3) && too_big(this) && runaway++ < 500) {
+                    if (eli !== 0) {
+                        // elipsis already inserted
+                        if ((eli - nsL) > (nsR - eli)) {
+                            // cut left
+                            start = eli - 2;
+                            length = 2;
+                        } else {
+                            // cut right
+                            start = eli + 1;
+                            length = 1;
+                        }
+                        replace = '';
+                    } else {
+                        // replace middle with ellipsis
+                        start = Math.floor(nsL + ((nsR - nsL) / 2));
+                        length = 1;
+                        replace = '…';
+                    }
+                    this.textContent = substr_replace(this.textContent,
+                        replace, start, length);
+
+                    eli = this.textContent.indexOf('…');
+                    nsL = this.textContent.indexOf('(');
+                    nsR = this.textContent.indexOf(')');
+                }
+            });
+
+            // reenable overflow
+            dw_qsearch.$outObj.find('li').css('overflow', 'hidden').css('text-overflow', 'ellipsis');
+        }
+
+
+    };
+
+    jQuery.extend(dw_qsearch, overrides);
+
+    if (!overrides.deferInit) {
+        dw_qsearch.init();
+    }
+
+    return dw_qsearch;
+};

--- a/style.css
+++ b/style.css
@@ -3,3 +3,76 @@
     top: auto;
     right: auto;
 }
+
+.searchform__form .searchform__qsearch_in::placeholder {color:lightgray;}
+
+.searchform__form form.search .button  {
+	display:inline-block;
+	border-radius:0;
+	padding:0;
+	cursor: pointer;
+	width:7em;
+	border: none;
+	height:50px;
+	font: bold 18px "Lucida Console", Monaco, monospace;
+	color: rgba(255,255,255,0.9);
+	background: LightSteelBlue;
+	margin-left:-5px;
+}
+
+/* search box input form */
+.searchform__form .searchform__qsearch_in {
+	max-width:400px;
+	width:50%;
+	height:2em;
+    display: inline-block;
+	-webkit-box-sizing: content-box;
+	-moz-box-sizing: content-box;
+	box-sizing: content-box;
+	padding: 5px 10px;
+	border: 2px solid LightSteelBlue;
+	font: normal 18px/normal "Lucida Console", Monaco, monospace;
+	line-height:1.5em;
+	color: black;
+	-o-text-overflow: clip;
+	text-overflow: clip;
+	border-radius:0;
+}
+
+/* search box results area */
+.searchform__form .searchform__qsearch_out {
+	width:730px !important;
+	border: 2px solid LightSteelBlue;
+	max-height:450px;
+	overflow-y:auto;
+}
+
+/* Styling the search results output */
+.qfs_result_num {
+	background: #eee;
+    margin-left: -7px;
+    margin-top: -7px;
+    margin-right: -7px;
+    color: gray;
+    font-size: 85%;
+    margin-bottom: 3px;
+    padding-left: 10px;
+}
+
+.qfs_result {
+	border-bottom: 1px solid lightgray;
+    border-top: 1px solid lightgray;
+    padding: 2px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    background: #f7f7f7;
+    font-size:90%;
+}
+
+.qfs_result .wikilink1 {
+	border-left:5px solid steelblue;
+	padding-left:6px;
+	font-size:115% !important;
+	font-weight:bold;
+	color:steelblue !important;
+}

--- a/syntax.php
+++ b/syntax.php
@@ -90,7 +90,7 @@ class syntax_plugin_searchform extends DokuWiki_Syntax_Plugin {
             $renderer->doc .= '<input type="hidden" class="searchform__ns" name="ns" value="' . $ns . '" />';
             $renderer->doc .= '<input type="text" ';
             if($ACT == 'search') $renderer->doc .= 'value="' . htmlspecialchars($QUERY) . '" ';
-            $renderer->doc .= 'name="id" class="edit searchform__qsearch_in" />' . "\n";
+            $renderer->doc .= 'name="id" class="edit searchform__qsearch_in" placeholder="' . $this->getLang('placeholder') . '" autocomplete="off" />' . "\n";
             $renderer->doc .= '<input type="submit" value="' . $lang['btn_search'] . '" class="button" title="' . $lang['btn_search'] . '" />' . "\n";
             $renderer->doc .= '<div class="ajax_qsearch JSpopup searchform__qsearch_out"></div>' . "\n";
             $renderer->doc .= '</div></form>' . "\n";


### PR DESCRIPTION
I changed the plugin to perform a fulltext search by modifying dokuwikis qsearch.js and adding it to the script.js of the plugin. Then I added an ajax call, so that the fulltext search is performed instead of the qsearch only listing pages. 

In addition, I added some fixed styling of the searchbox. 

![image](https://user-images.githubusercontent.com/60605145/76316391-d25e2800-62da-11ea-8625-409f9178f4a3.png)
